### PR TITLE
add `%w` string verb highlighting recognition

### DIFF
--- a/syntaxes/go.tmLanguage.json
+++ b/syntaxes/go.tmLanguage.json
@@ -58,7 +58,7 @@
         "string_placeholder": {
             "patterns": [
                 {
-                    "match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]",
+                    "match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGspw]",
                     "name": "constant.other.placeholder.go"
                 }
             ]


### PR DESCRIPTION
error format verb `%w` is not recognized 
```go
fmt.Errorf("some error information: %w", err)
```
The `%w` verb was not recognized as `%v` is, for example; it has now been added.